### PR TITLE
noted a typing on gen_tcp hostname issue

### DIFF
--- a/lib/sonix.ex
+++ b/lib/sonix.ex
@@ -9,10 +9,15 @@ defmodule Sonix do
 
   @doc """
   Initializes Tcp Client Genserver
+  
+  If the `host` parameter value is as a hostname `String` then it should convert to charlists structure by `Kernel.to_charlist/1`.
 
   ## Examples
 
   iex> Sonix.init()
+  #PID<0.177.0>
+  
+  iex> Sonix.init(Kernel.to_charlist("sonic_hostname"))
   #PID<0.177.0>
 
   """


### PR DESCRIPTION
Updated `init` function comments to describe how to pass a correct hostname to `gen_tcp`.

Links:
- https://elixirforum.com/t/do-i-have-to-provide-an-actual-numerical-ip-address-to-gen-tcp-connect/7461